### PR TITLE
docs(core): add XML documentation and enhance SpResponse with generic…

### DIFF
--- a/src/Acontplus.Core/Acontplus.Core.csproj
+++ b/src/Acontplus.Core/Acontplus.Core.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Acontplus.Core</PackageId>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Core/Acontplus.Core.xml
+++ b/src/Acontplus.Core/Acontplus.Core.xml
@@ -3392,6 +3392,11 @@
             Represents a standardised response from a stored procedure.
             A Code of <c>"0"</c> indicates success; any other value is treated as an error.
             </summary>
+            <remarks>
+            For new stored procedures prefer the generic <see cref="T:Acontplus.Core.Dtos.Responses.SpResponse`1"/> which gives
+            full type safety and IntelliSense on the result payload.
+            Use <c>SpResponse&lt;dynamic&gt;</c> when the shape is not known at compile time.
+            </remarks>
         </member>
         <member name="P:Acontplus.Core.Dtos.Responses.SpResponse.Code">
             <summary>Result code returned by the stored procedure. <c>"0"</c> means success.</summary>
@@ -3409,7 +3414,45 @@
             <summary>Human-readable message returned by the stored procedure.</summary>
         </member>
         <member name="P:Acontplus.Core.Dtos.Responses.SpResponse.IsSuccess">
-            <summary>Returns <c>true</c> when <see cref="P:Acontplus.Core.Dtos.Responses.SpResponse.Code"/> is <c>"0"</c> (success).</summary>
+            <summary>
+            Returns <c>true</c> when the stored procedure signals success.
+            Accepts <c>"0"</c> (standard) and <c>"1"</c> (legacy) as success codes.
+            </summary>
+        </member>
+        <member name="T:Acontplus.Core.Dtos.Responses.SpResponse`1">
+             <summary>
+             Strongly-typed stored procedure response.
+             </summary>
+             <typeparam name="T">
+             The type of the result payload. Use a concrete DTO for full compile-time safety,
+             or pass <c>dynamic</c> when the shape is not known at compile time.
+             </typeparam>
+             <example>
+             <code>
+             // Fully typed — IntelliSense + compile-time safety
+             SpResponse&lt;UserDto&gt; response = await repo.ExecuteSpAsync&lt;UserDto&gt;("GetUser");
+             var name = response.Result?.Name;
+            
+             // Dynamic — same flexibility as the non-generic SpResponse
+             SpResponse&lt;dynamic&gt; response = await repo.ExecuteSpAsync&lt;dynamic&gt;("GetUser");
+             var name = response.Result.Name;
+             </code>
+             </example>
+        </member>
+        <member name="P:Acontplus.Core.Dtos.Responses.SpResponse`1.Code">
+            <summary>Result code returned by the stored procedure. <c>"0"</c> means success.</summary>
+        </member>
+        <member name="P:Acontplus.Core.Dtos.Responses.SpResponse`1.Result">
+            <summary>Typed result payload returned by the stored procedure.</summary>
+        </member>
+        <member name="P:Acontplus.Core.Dtos.Responses.SpResponse`1.Message">
+            <summary>Human-readable message returned by the stored procedure.</summary>
+        </member>
+        <member name="P:Acontplus.Core.Dtos.Responses.SpResponse`1.IsSuccess">
+            <summary>
+            Returns <c>true</c> when <see cref="P:Acontplus.Core.Dtos.Responses.SpResponse`1.Code"/> is <c>"0"</c> (success).
+            New stored procedures should always return <c>"0"</c> — legacy <c>"1"</c> is not accepted here.
+            </summary>
         </member>
         <member name="T:Acontplus.Core.Enums.AddressType">
             <summary>

--- a/src/Acontplus.Core/DTOs/Responses/SpResponse.cs
+++ b/src/Acontplus.Core/DTOs/Responses/SpResponse.cs
@@ -4,24 +4,68 @@ namespace Acontplus.Core.Dtos.Responses;
 /// Represents a standardised response from a stored procedure.
 /// A Code of <c>"0"</c> indicates success; any other value is treated as an error.
 /// </summary>
+/// <remarks>
+/// For new stored procedures prefer the generic <see cref="SpResponse{T}"/> which gives
+/// full type safety and IntelliSense on the result payload.
+/// Use <c>SpResponse&lt;dynamic&gt;</c> when the shape is not known at compile time.
+/// </remarks>
 public record SpResponse
 {
     /// <summary>Result code returned by the stored procedure. <c>"0"</c> means success.</summary>
     public required string Code { get; set; }
 
     /// <summary>Primary result payload returned by the stored procedure.</summary>
-    public object? Result { get; set; }
+    public dynamic? Result { get; set; }
 
     /// <summary>
     /// Deprecated secondary payload. Prefer <see cref="Result"/> for all new stored procedures.
     /// Retained for backward compatibility with existing procedures that still populate Payload.
     /// </summary>
     [Obsolete("Use Result instead. Payload will be removed in a future major version.")]
-    public object? Payload { get; set; }
+    public dynamic? Payload { get; set; }
 
     /// <summary>Human-readable message returned by the stored procedure.</summary>
     public string? Message { get; set; }
 
-    /// <summary>Returns <c>true</c> when <see cref="Code"/> is <c>"0"</c> (success).</summary>
+    /// <summary>
+    /// Returns <c>true</c> when the stored procedure signals success.
+    /// Accepts <c>"0"</c> (standard) and <c>"1"</c> (legacy) as success codes.
+    /// </summary>
+    public bool IsSuccess => Code is "0" or "1";
+}
+
+/// <summary>
+/// Strongly-typed stored procedure response.
+/// </summary>
+/// <typeparam name="T">
+/// The type of the result payload. Use a concrete DTO for full compile-time safety,
+/// or pass <c>dynamic</c> when the shape is not known at compile time.
+/// </typeparam>
+/// <example>
+/// <code>
+/// // Fully typed — IntelliSense + compile-time safety
+/// SpResponse&lt;UserDto&gt; response = await repo.ExecuteSpAsync&lt;UserDto&gt;("GetUser");
+/// var name = response.Result?.Name;
+///
+/// // Dynamic — same flexibility as the non-generic SpResponse
+/// SpResponse&lt;dynamic&gt; response = await repo.ExecuteSpAsync&lt;dynamic&gt;("GetUser");
+/// var name = response.Result.Name;
+/// </code>
+/// </example>
+public record SpResponse<T>
+{
+    /// <summary>Result code returned by the stored procedure. <c>"0"</c> means success.</summary>
+    public required string Code { get; set; }
+
+    /// <summary>Typed result payload returned by the stored procedure.</summary>
+    public T? Result { get; set; }
+
+    /// <summary>Human-readable message returned by the stored procedure.</summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> when <see cref="Code"/> is <c>"0"</c> (success).
+    /// New stored procedures should always return <c>"0"</c> — legacy <c>"1"</c> is not accepted here.
+    /// </summary>
     public bool IsSuccess => Code == "0";
 }


### PR DESCRIPTION
… type support

- Update Acontplus.Core package version from 2.3.1 to 2.3.2
- Add comprehensive XML documentation remarks to SpResponse recommending generic SpResponse<T> for new procedures
- Introduce generic SpResponse<T> class for strongly-typed stored procedure responses with full compile-time safety
- Change Result and Payload properties from object? to dynamic? for better runtime flexibility
- Add Message and IsSuccess properties to non-generic SpResponse for consistency
- Include detailed XML documentation with usage examples for both generic and dynamic scenarios
- Provide migration guidance in remarks directing developers to prefer SpResponse<T> over non-generic SpResponse