### PR TITLE
feat(persistence): implement automatic audit field population via int…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## Acontplus.Persistence.PostgreSQL
+
+### [1.4.0]
+
+- **Added** `AuditSaveChangesInterceptor` — EF Core `SaveChangesInterceptor` that automatically populates audit fields (`CreatedBy`, `CreatedByUserId`, `IsMobileRequest`, `UpdatedBy`, `UpdatedByUserId`, `DeletedBy`, `DeletedByUserId`) on every `BaseEntity` before saving
+- **Fixed** Audit identity fields now correctly captured per-request under `AddDbContextPool`. The old constructor-injection approach captured the first request's user permanently on each pooled context instance; `CreateScope()` per save resolves a fresh `IAuditContext` every time
+- **Changed** `AddPostgresPersistence<TContext>` now registers `AuditSaveChangesInterceptor` as a singleton and injects it into the `DbContextPool` factory; requires no extra configuration
+- **Changed** `BaseContext` — removed `IAuditContext` constructor overloads; timestamps (`CreatedAt`, `UpdatedAt`, `DeletedAt`) are still managed by `BaseContext`; user-identity fields are now exclusively handled by `AuditSaveChangesInterceptor`
+- **Changed** Audit stamping is a no-op when `IAuditContext` is not registered in DI
+
+---
+
+## Acontplus.Persistence.SqlServer
+
+### [2.2.0]
+
+- **Added** `AuditSaveChangesInterceptor` — EF Core `SaveChangesInterceptor` that automatically populates audit fields (`CreatedBy`, `CreatedByUserId`, `IsMobileRequest`, `UpdatedBy`, `UpdatedByUserId`, `DeletedBy`, `DeletedByUserId`) on every `BaseEntity` before saving
+- **Fixed** Audit identity fields now correctly captured per-request under `AddDbContextPool`. The old constructor-injection approach captured the first request's user permanently on each pooled context instance; `CreateScope()` per save resolves a fresh `IAuditContext` every time
+- **Changed** `AddSqlServerPersistence<TContext>` now registers `AuditSaveChangesInterceptor` as a singleton and injects it into the `DbContextPool` factory; requires no extra configuration
+- **Changed** `BaseContext` — removed `IAuditContext` constructor overloads; timestamps (`CreatedAt`, `UpdatedAt`, `DeletedAt`) are still managed by `BaseContext`; user-identity fields are now exclusively handled by `AuditSaveChangesInterceptor`
+- **Changed** Audit stamping is a no-op when `IAuditContext` is not registered in DI
+
+---
+
 ## Acontplus.Logging
 
 ### [2.0.0]

--- a/apps/src/Demo.Infrastructure/Persistence/TestContext.cs
+++ b/apps/src/Demo.Infrastructure/Persistence/TestContext.cs
@@ -4,8 +4,8 @@ namespace Demo.Infrastructure.Persistence;
 
 public class TestContext : BaseContext
 {
-    public TestContext(DbContextOptions<TestContext> options, IAuditContext auditContext)
-        : base(options, auditContext) { }
+    public TestContext(DbContextOptions<TestContext> options)
+        : base(options) { }
 
     public DbSet<Dia> Dias { get; set; }
     public DbSet<Usuario> Usuarios { get; set; }

--- a/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.csproj
+++ b/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Acontplus.Persistence.PostgreSQL</PackageId>
-    <Version>1.3.8</Version>
+    <Version>1.4.0</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.xml
+++ b/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.xml
@@ -195,62 +195,63 @@
         </member>
         <member name="T:Acontplus.Persistence.PostgreSQL.Context.BaseContext">
             <summary>
-            Base context class for Entity Framework Core database contexts with support for domain events, auditing, and soft deletes.
+            Base EF Core database context for PostgreSQL with support for domain events, timestamp auditing, and soft deletes.
             </summary>
+            <remarks>
+            Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+            <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+            <see cref="T:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddPostgresPersistence</c>.
+            This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+            hard-delete → soft-delete conversion.
+            </remarks>
             <param name="options">The options to be used by the DbContext.</param>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions)">
             <summary>
-            Base context class for Entity Framework Core database contexts with support for domain events, auditing, and soft deletes.
+            Base EF Core database context for PostgreSQL with support for domain events, timestamp auditing, and soft deletes.
             </summary>
+            <remarks>
+            Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+            <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+            <see cref="T:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddPostgresPersistence</c>.
+            This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+            hard-delete → soft-delete conversion.
+            </remarks>
             <param name="options">The options to be used by the DbContext.</param>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Domain.Common.Events.IDomainEventDispatcher)">
             <summary>
-            Initializes a new instance of the <see cref="T:Acontplus.Persistence.PostgreSQL.Context.BaseContext"/> class with domain event dispatcher.
+            Initializes a new instance with a domain event dispatcher.
             </summary>
             <param name="options">The options to be used by the DbContext.</param>
-            <param name="eventDispatcher">The domain event dispatcher for handling domain events.</param>
-        </member>
-        <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Domain.Common.Events.IDomainEventDispatcher,Acontplus.Core.Abstractions.Context.IAuditContext)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Acontplus.Persistence.PostgreSQL.Context.BaseContext"/> class with domain event dispatcher and audit context.
-            </summary>
-            <param name="options">The options to be used by the DbContext.</param>
-            <param name="eventDispatcher">The domain event dispatcher for handling domain events.</param>
-            <param name="auditContext">The audit context for tracking user information.</param>
-        </member>
-        <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Abstractions.Context.IAuditContext)">
-            <summary>
-            Initializes a new instance of the <see cref="T:Acontplus.Persistence.PostgreSQL.Context.BaseContext"/> class with audit context.
-            </summary>
-            <param name="options">The options to be used by the DbContext.</param>
-            <param name="auditContext">The audit context for tracking user information.</param>
+            <param name="eventDispatcher">The domain event dispatcher.</param>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.SaveChangesAsync(System.Threading.CancellationToken)">
-            <summary>
-            Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes asynchronously.
-            </summary>
-            <param name="cancellationToken">A token to cancel the operation.</param>
-            <returns>The number of state entries written to the database.</returns>
+            <inheritdoc/>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.SaveChanges">
+            <inheritdoc/>
+        </member>
+        <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.UpdateTimestamps">
             <summary>
-            Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes synchronously.
+            Stamps <c>CreatedAt</c> on added entities and <c>UpdatedAt</c> on modified entities.
+            User-identity fields are handled by <see cref="T:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>.
             </summary>
-            <returns>The number of state entries written to the database.</returns>
+        </member>
+        <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.HandleSoftDeletes">
+            <summary>
+            Converts hard-deletes into soft-deletes and handles restore logic.
+            User-identity fields on deletion (<c>DeletedBy</c>, <c>DeletedByUserId</c>) are handled
+            by <see cref="T:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>.
+            </summary>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.OnModelCreating(Microsoft.EntityFrameworkCore.ModelBuilder)">
-            <summary>
-            Configures the model by applying global soft-delete filters and date-time conversions.
-            </summary>
-            <param name="modelBuilder">The model builder used to construct the model for the context.</param>
+            <inheritdoc/>
         </member>
         <member name="M:Acontplus.Persistence.PostgreSQL.Context.BaseContext.ConfigureDateTimeProperties(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <summary>
-            Applies UTC-aware value converters to all <see cref="T:System.DateTime"/> and <see cref="T:System.Nullable`1"/> DateTime properties.
+            Applies UTC-aware value converters to all <see cref="T:System.DateTime"/> and nullable DateTime properties.
             </summary>
-            <param name="builder">The model builder.</param>
         </member>
         <member name="T:Acontplus.Persistence.PostgreSQL.DependencyInjection.PostgresServiceCollectionExtensions">
             <summary>
@@ -371,6 +372,36 @@
             <param name="message">The error message that explains the reason for the exception.</param>
             <param name="innerException">The exception that is the cause of the current exception, or a null reference
             (Nothing in Visual Basic) if no inner exception is specified.</param>
+        </member>
+        <member name="T:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor">
+            <summary>
+            A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+            <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+            <see cref="T:Acontplus.Core.Domain.Common.Entities.BaseEntity"/> before changes are persisted.
+            </summary>
+            <remarks>
+            Registered automatically by <c>AddPostgresPersistence</c>.  Resolves
+            <see cref="T:Acontplus.Core.Abstractions.Context.IAuditContext"/> from a fresh DI scope on each save, so it is
+            safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+            </remarks>
+        </member>
+        <member name="M:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor.#ctor(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory)">
+            <summary>
+            A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+            <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+            <see cref="T:Acontplus.Core.Domain.Common.Entities.BaseEntity"/> before changes are persisted.
+            </summary>
+            <remarks>
+            Registered automatically by <c>AddPostgresPersistence</c>.  Resolves
+            <see cref="T:Acontplus.Core.Abstractions.Context.IAuditContext"/> from a fresh DI scope on each save, so it is
+            safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+            </remarks>
+        </member>
+        <member name="M:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor.SavingChanges(Microsoft.EntityFrameworkCore.Diagnostics.DbContextEventData,Microsoft.EntityFrameworkCore.Diagnostics.InterceptionResult{System.Int32})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor.SavingChangesAsync(Microsoft.EntityFrameworkCore.Diagnostics.DbContextEventData,Microsoft.EntityFrameworkCore.Diagnostics.InterceptionResult{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc/>
         </member>
         <member name="T:Acontplus.Persistence.PostgreSQL.Mapping.DataTableNameMapper">
             <summary>

--- a/src/Acontplus.Persistence.PostgreSQL/Context/BaseContext.cs
+++ b/src/Acontplus.Persistence.PostgreSQL/Context/BaseContext.cs
@@ -1,234 +1,176 @@
 namespace Acontplus.Persistence.PostgreSQL.Context;
 
 /// <summary>
-/// Base context class for Entity Framework Core database contexts with support for domain events, auditing, and soft deletes.
+/// Base EF Core database context for PostgreSQL with support for domain events, timestamp auditing, and soft deletes.
 /// </summary>
+/// <remarks>
+/// Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+/// <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+/// <see cref="Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddPostgresPersistence</c>.
+/// This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+/// hard-delete → soft-delete conversion.
+/// </remarks>
 /// <param name="options">The options to be used by the DbContext.</param>
 public abstract class BaseContext(DbContextOptions options) : DbContext(options)
 {
-    private readonly IDomainEventDispatcher? _eventDispatcher;
-    private readonly IAuditContext? _auditContext;
+  private readonly IDomainEventDispatcher? _eventDispatcher;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BaseContext"/> class with domain event dispatcher.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="eventDispatcher">The domain event dispatcher for handling domain events.</param>
-    protected BaseContext(DbContextOptions options, IDomainEventDispatcher eventDispatcher)
-        : this(options)
+  /// <summary>
+  /// Initializes a new instance with a domain event dispatcher.
+  /// </summary>
+  /// <param name="options">The options to be used by the DbContext.</param>
+  /// <param name="eventDispatcher">The domain event dispatcher.</param>
+  protected BaseContext(DbContextOptions options, IDomainEventDispatcher eventDispatcher)
+    : this(options)
+  {
+    _eventDispatcher = eventDispatcher;
+  }
+
+  /// <inheritdoc/>
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    await DispatchDomainEventsAsync();
+    UpdateTimestamps();
+    HandleSoftDeletes();
+    return await base.SaveChangesAsync(cancellationToken);
+  }
+
+  /// <inheritdoc/>
+  public override int SaveChanges()
+  {
+    DispatchDomainEventsAsync().GetAwaiter().GetResult();
+    UpdateTimestamps();
+    HandleSoftDeletes();
+    return base.SaveChanges();
+  }
+
+  private async Task DispatchDomainEventsAsync()
+  {
+    if (_eventDispatcher is null) return;
+
+    var entitiesWithEvents = ChangeTracker
+      .Entries<IEntityWithDomainEvents>()
+      .Where(e => e.Entity.DomainEvents.Any())
+      .Select(e => e.Entity)
+      .ToList();
+
+    foreach (var entity in entitiesWithEvents)
     {
-        _eventDispatcher = eventDispatcher;
+      var events = entity.DomainEvents.ToArray();
+      entity.ClearDomainEvents();
+      foreach (var domainEvent in events)
+        await _eventDispatcher.Dispatch(domainEvent);
     }
+  }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BaseContext"/> class with domain event dispatcher and audit context.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="eventDispatcher">The domain event dispatcher for handling domain events.</param>
-    /// <param name="auditContext">The audit context for tracking user information.</param>
-    protected BaseContext(
-        DbContextOptions options,
-        IDomainEventDispatcher eventDispatcher,
-        IAuditContext auditContext)
-        : this(options, eventDispatcher)
+  /// <summary>
+  /// Stamps <c>CreatedAt</c> on added entities and <c>UpdatedAt</c> on modified entities.
+  /// User-identity fields are handled by <see cref="Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>.
+  /// </summary>
+  private void UpdateTimestamps()
+  {
+    foreach (var entry in ChangeTracker.Entries<BaseEntity>()
+               .Where(e => e.State is EntityState.Added or EntityState.Modified))
     {
-        _auditContext = auditContext;
+      if (entry.State == EntityState.Added)
+        entry.Entity.CreatedAt = DateTime.UtcNow;
+      else
+        entry.Entity.UpdatedAt = DateTime.UtcNow;
     }
+  }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BaseContext"/> class with audit context.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="auditContext">The audit context for tracking user information.</param>
-    protected BaseContext(DbContextOptions options, IAuditContext auditContext)
-        : this(options)
+  /// <summary>
+  /// Converts hard-deletes into soft-deletes and handles restore logic.
+  /// User-identity fields on deletion (<c>DeletedBy</c>, <c>DeletedByUserId</c>) are handled
+  /// by <see cref="Acontplus.Persistence.PostgreSQL.Interceptors.AuditSaveChangesInterceptor"/>.
+  /// </summary>
+  private void HandleSoftDeletes()
+  {
+    var entries = ChangeTracker.Entries<BaseEntity>()
+      .Where(e => e.State == EntityState.Deleted ||
+                  e.Property(nameof(BaseEntity.IsDeleted)).IsModified)
+      .ToList();
+
+    foreach (var entry in entries)
     {
-        _auditContext = auditContext;
+      var entity = entry.Entity;
+
+      if (entry.State == EntityState.Deleted || entity.IsDeleted)
+      {
+        // Convert hard-delete into a soft-delete
+        entry.State = EntityState.Modified;
+        entity.IsDeleted = true;
+        entity.IsActive = false;
+        entity.DeletedAt = DateTime.UtcNow;
+      }
+      else if (!entity.IsDeleted && entity.DeletedAt is not null)
+      {
+        // Restore from soft-delete — clear all deletion stamps
+        entity.DeletedAt = null;
+        entity.DeletedByUserId = null;
+        entity.DeletedBy = null;
+        entity.IsActive = true;
+        entity.UpdatedAt = DateTime.UtcNow;
+      }
     }
+  }
 
-    /// <summary>
-    /// Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes asynchronously.
-    /// </summary>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>The number of state entries written to the database.</returns>
-    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  /// <inheritdoc/>
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    base.OnModelCreating(modelBuilder);
+
+    ConfigureGlobalFilters(modelBuilder);
+    ConfigureDateTimeProperties(modelBuilder);
+  }
+
+  private static void ConfigureGlobalFilters(ModelBuilder builder)
+  {
+    foreach (var entityType in builder.Model.GetEntityTypes())
     {
-        await DispatchDomainEventsAsync();
-        // Only update audit fields and handle soft deletes for auditable entities
-        await UpdateAuditFieldsAsync();
-        await HandleSoftDeletesAsync();
-
-        var result = await base.SaveChangesAsync(cancellationToken);
-        return result;
+      if (typeof(BaseEntity).IsAssignableFrom(entityType.ClrType))
+      {
+        var parameter = Expression.Parameter(entityType.ClrType, "e");
+        var property = Expression.Property(parameter, nameof(BaseEntity.IsDeleted));
+        var condition = Expression.Lambda(Expression.Not(property), parameter);
+        builder.Entity(entityType.ClrType).HasQueryFilter(condition);
+      }
     }
+  }
 
-    /// <summary>
-    /// Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes synchronously.
-    /// </summary>
-    /// <returns>The number of state entries written to the database.</returns>
-    public override int SaveChanges()
+  /// <summary>
+  /// Applies UTC-aware value converters to all <see cref="DateTime"/> and nullable DateTime properties.
+  /// </summary>
+  protected virtual void ConfigureDateTimeProperties(ModelBuilder builder)
+  {
+    foreach (var entityType in builder.Model.GetEntityTypes())
     {
-        DispatchDomainEventsAsync().GetAwaiter().GetResult();
-        // Only update audit fields and handle soft deletes for auditable entities
-        UpdateAuditFieldsAsync().GetAwaiter().GetResult();
-        HandleSoftDeletesAsync().GetAwaiter().GetResult();
-
-        return base.SaveChanges();
-    }
-
-    private async Task DispatchDomainEventsAsync()
-    {
-        if (_eventDispatcher == null) return;
-
-        var entitiesWithEvents = ChangeTracker
-            .Entries<IEntityWithDomainEvents>()
-            .Where(e => e.Entity.DomainEvents.Any())
-            .Select(e => e.Entity)
-            .ToList();
-
-        foreach (var entity in entitiesWithEvents)
+      foreach (var property in entityType.GetProperties()
+                 .Where(p => p.ClrType == typeof(DateTime) || p.ClrType == typeof(DateTime?)))
+      {
+        if (property.ClrType == typeof(DateTime))
         {
-            var events = entity.DomainEvents.ToArray();
-            entity.ClearDomainEvents();
-
-            foreach (var domainEvent in events)
-            {
-                await _eventDispatcher.Dispatch(domainEvent);
-            }
+          builder.Entity(entityType.ClrType)
+            .Property<DateTime>(property.Name)
+            .HasConversion(
+              v => v.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(v, DateTimeKind.Utc)
+                : v.ToUniversalTime(),
+              v => v);
         }
-    }
-
-    private Task UpdateAuditFieldsAsync()
-    {
-        var entries = ChangeTracker.Entries()
-            .Where(e => e.Entity is BaseEntity &&
-                        (e.State == EntityState.Added || e.State == EntityState.Modified))
-            .ToList();
-
-        foreach (var entry in entries)
+        else
         {
-            var entity = (BaseEntity)entry.Entity;
-
-            if (entry.State == EntityState.Added)
-            {
-                entity.CreatedAt = DateTime.UtcNow;
-                entity.CreatedByUserId = _auditContext?.UserId;
-                entity.CreatedBy = _auditContext?.UserName;
-                entity.IsMobileRequest = _auditContext?.IsMobile ?? entity.IsMobileRequest;
-            }
-            else
-            {
-                entity.UpdatedAt = DateTime.UtcNow;
-                entity.UpdatedByUserId = _auditContext?.UserId;
-                entity.UpdatedBy = _auditContext?.UserName;
-            }
+          builder.Entity(entityType.ClrType)
+            .Property<DateTime?>(property.Name)
+            .HasConversion(
+              v => v.HasValue
+                ? v.Value.Kind == DateTimeKind.Unspecified
+                  ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                  : v.Value.ToUniversalTime()
+                : (DateTime?)null,
+              v => v);
         }
-
-        return Task.CompletedTask;
+      }
     }
-
-    private Task HandleSoftDeletesAsync()
-    {
-        var entries = ChangeTracker.Entries()
-            .Where(e => e.Entity is BaseEntity &&
-                        (e.State == EntityState.Deleted ||
-                         e.Property(nameof(BaseEntity.IsDeleted)).IsModified))
-            .ToList();
-
-        foreach (var entry in entries)
-        {
-            var entity = (BaseEntity)entry.Entity;
-
-            if (entry.State == EntityState.Deleted || entity.IsDeleted)
-            {
-                // Convert hard-delete into a soft-delete
-                entry.State = EntityState.Modified;
-                entity.IsDeleted = true;
-                entity.IsActive = false;
-                entity.DeletedAt = DateTime.UtcNow;
-                entity.DeletedByUserId = _auditContext?.UserId;
-                entity.DeletedBy = _auditContext?.UserName;
-            }
-            else if (!entity.IsDeleted && entity.DeletedAt is not null)
-            {
-                // Restore from soft-delete — clear all deletion stamps
-                entity.DeletedAt = null;
-                entity.DeletedByUserId = null;
-                entity.DeletedBy = null;
-                entity.IsActive = true;
-                entity.UpdatedAt = DateTime.UtcNow;
-                entity.UpdatedByUserId = _auditContext?.UserId;
-                entity.UpdatedBy = _auditContext?.UserName;
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Configures the model by applying global soft-delete filters and date-time conversions.
-    /// </summary>
-    /// <param name="modelBuilder">The model builder used to construct the model for the context.</param>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-
-        ConfigureGlobalFilters(modelBuilder);
-        ConfigureDateTimeProperties(modelBuilder);
-    }
-
-    private static void ConfigureGlobalFilters(ModelBuilder builder)
-    {
-        // Only apply soft delete filter to auditable entities
-        foreach (var entityType in builder.Model.GetEntityTypes())
-        {
-            if (typeof(BaseEntity).IsAssignableFrom(entityType.ClrType))
-            {
-                var parameter = Expression.Parameter(entityType.ClrType, "e");
-                var property = Expression.Property(parameter, nameof(BaseEntity.IsDeleted));
-                var condition = Expression.Lambda(Expression.Not(property), parameter);
-
-                builder.Entity(entityType.ClrType).HasQueryFilter(condition);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Applies UTC-aware value converters to all <see cref="DateTime"/> and <see cref="Nullable{T}"/> DateTime properties.
-    /// </summary>
-    /// <param name="builder">The model builder.</param>
-    protected virtual void ConfigureDateTimeProperties(ModelBuilder builder)
-    {
-        foreach (var entityType in builder.Model.GetEntityTypes())
-        {
-            foreach (var property in entityType.GetProperties()
-                         .Where(p => p.ClrType == typeof(DateTime) || p.ClrType == typeof(DateTime?)))
-            {
-                if (property.ClrType == typeof(DateTime))
-                {
-                    builder.Entity(entityType.ClrType)
-                        .Property<DateTime>(property.Name)
-                        .HasConversion(
-                            v => v.Kind == DateTimeKind.Unspecified
-                                ? DateTime.SpecifyKind(v, DateTimeKind.Utc)
-                                : v.ToUniversalTime(),
-                            v => v
-                        );
-                }
-                else
-                {
-                    builder.Entity(entityType.ClrType)
-                        .Property<DateTime?>(property.Name)
-                        .HasConversion(
-                            v => v.HasValue
-                                ? v.Value.Kind == DateTimeKind.Unspecified
-                                    ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
-                                    : v.Value.ToUniversalTime()
-                                : (DateTime?)null,
-                            v => v
-                        );
-                }
-            }
-        }
-    }
+  }
 }

--- a/src/Acontplus.Persistence.PostgreSQL/DependencyInjection/PostgresServiceCollectionExtensions.cs
+++ b/src/Acontplus.Persistence.PostgreSQL/DependencyInjection/PostgresServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Acontplus.Persistence.Common.Configuration;
+using Acontplus.Persistence.PostgreSQL.Interceptors;
 using Acontplus.Persistence.PostgreSQL.Repositories;
 
 namespace Acontplus.Persistence.PostgreSQL.DependencyInjection;
@@ -8,102 +9,108 @@ namespace Acontplus.Persistence.PostgreSQL.DependencyInjection;
 /// </summary>
 public static class PostgresServiceCollectionExtensions
 {
-    /// <summary>
-    /// Ensures PersistenceResilienceOptions is registered with default values.
-    /// Called internally by persistence registration methods.
-    /// To configure from appsettings.json, add this in your Startup/Program.cs:
-    /// services.Configure&lt;PersistenceResilienceOptions&gt;(configuration.GetSection("Persistence:Resilience"));
-    /// </summary>
-    private static void EnsureResilienceOptionsRegistered(IServiceCollection services)
+  /// <summary>
+  /// Ensures PersistenceResilienceOptions is registered with default values.
+  /// Called internally by persistence registration methods.
+  /// To configure from appsettings.json, add this in your Startup/Program.cs:
+  /// services.Configure&lt;PersistenceResilienceOptions&gt;(configuration.GetSection("Persistence:Resilience"));
+  /// </summary>
+  private static void EnsureResilienceOptionsRegistered(IServiceCollection services)
+  {
+    services.TryAddSingleton<Microsoft.Extensions.Options.IOptions<PersistenceResilienceOptions>>(
+        sp => Microsoft.Extensions.Options.Options.Create(new PersistenceResilienceOptions()));
+  }
+
+  /// <summary>
+  /// Registers a PostgreSQL DbContext and its corresponding UnitOfWork implementation,
+  /// optionally with a service key using .NET 8+ keyed DI.
+  /// Also registers IAdoRepository which is required by UnitOfWork.
+  /// </summary>
+  /// <typeparam name="TContext">The DbContext type to register.</typeparam>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="postgresOptions">The PostgreSQL-specific options for DbContext.</param>
+  /// <param name="serviceKey">Optional key to register the services with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddPostgresPersistence<TContext>(
+      this IServiceCollection services,
+      Action<DbContextOptionsBuilder> postgresOptions,
+      object? serviceKey = null)
+      where TContext : DbContext
+  {
+    services.TryAddSingleton<AuditSaveChangesInterceptor>();
+
+    services.AddDbContextPool<TContext>((sp, options) =>
     {
-        services.TryAddSingleton<Microsoft.Extensions.Options.IOptions<PersistenceResilienceOptions>>(
-            sp => Microsoft.Extensions.Options.Options.Create(new PersistenceResilienceOptions()));
+      postgresOptions(options);
+      options.AddInterceptors(sp.GetRequiredService<AuditSaveChangesInterceptor>());
+    }, poolSize: 128);
+
+    EnsureResilienceOptionsRegistered(services);
+
+    // Register IAdoRepository which is required by UnitOfWork
+    if (serviceKey is not null)
+    {
+      services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
+      services.TryAddKeyedScoped<IUnitOfWork, UnitOfWork<TContext>>(serviceKey);
+      services.TryAddKeyedScoped<DbContext>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<TContext>(key));
+    }
+    else
+    {
+      services.TryAddScoped<IAdoRepository, AdoRepository>();
+      services.TryAddScoped<IUnitOfWork, UnitOfWork<TContext>>();
+      services.TryAddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
     }
 
-    /// <summary>
-    /// Registers a PostgreSQL DbContext and its corresponding UnitOfWork implementation,
-    /// optionally with a service key using .NET 8+ keyed DI.
-    /// Also registers IAdoRepository which is required by UnitOfWork.
-    /// </summary>
-    /// <typeparam name="TContext">The DbContext type to register.</typeparam>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="postgresOptions">The PostgreSQL-specific options for DbContext.</param>
-    /// <param name="serviceKey">Optional key to register the services with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddPostgresPersistence<TContext>(
-        this IServiceCollection services,
-        Action<DbContextOptionsBuilder> postgresOptions,
-        object? serviceKey = null)
-        where TContext : DbContext
+    return services;
+  }
+
+  /// <summary>
+  /// Registers the Dapper repository for PostgreSQL with resilience policies.
+  /// Can be used independently or alongside Entity Framework Core.
+  /// </summary>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddPostgresDapperRepository(
+      this IServiceCollection services,
+      object? serviceKey = null)
+  {
+    EnsureResilienceOptionsRegistered(services);
+
+    if (serviceKey is not null)
     {
-        services.AddDbContextPool<TContext>(postgresOptions, poolSize: 128);
-
-        EnsureResilienceOptionsRegistered(services);
-
-        // Register IAdoRepository which is required by UnitOfWork
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
-            services.TryAddKeyedScoped<IUnitOfWork, UnitOfWork<TContext>>(serviceKey);
-            services.TryAddKeyedScoped<DbContext>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<TContext>(key));
-        }
-        else
-        {
-            services.TryAddScoped<IAdoRepository, AdoRepository>();
-            services.TryAddScoped<IUnitOfWork, UnitOfWork<TContext>>();
-            services.TryAddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
-        }
-
-        return services;
+      services.TryAddKeyedScoped<IDapperRepository, DapperRepository>(serviceKey);
+    }
+    else
+    {
+      services.TryAddScoped<IDapperRepository, DapperRepository>();
     }
 
-    /// <summary>
-    /// Registers the Dapper repository for PostgreSQL with resilience policies.
-    /// Can be used independently or alongside Entity Framework Core.
-    /// </summary>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddPostgresDapperRepository(
-        this IServiceCollection services,
-        object? serviceKey = null)
+    return services;
+  }
+
+  /// <summary>
+  /// Registers the ADO.NET repository for PostgreSQL with resilience policies.
+  /// Can be used independently or alongside Entity Framework Core.
+  /// </summary>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddPostgresAdoRepository(
+      this IServiceCollection services,
+      object? serviceKey = null)
+  {
+    EnsureResilienceOptionsRegistered(services);
+
+    if (serviceKey is not null)
     {
-        EnsureResilienceOptionsRegistered(services);
-
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IDapperRepository, DapperRepository>(serviceKey);
-        }
-        else
-        {
-            services.TryAddScoped<IDapperRepository, DapperRepository>();
-        }
-
-        return services;
+      services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
+    }
+    else
+    {
+      services.TryAddScoped<IAdoRepository, AdoRepository>();
     }
 
-    /// <summary>
-    /// Registers the ADO.NET repository for PostgreSQL with resilience policies.
-    /// Can be used independently or alongside Entity Framework Core.
-    /// </summary>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddPostgresAdoRepository(
-        this IServiceCollection services,
-        object? serviceKey = null)
-    {
-        EnsureResilienceOptionsRegistered(services);
-
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
-        }
-        else
-        {
-            services.TryAddScoped<IAdoRepository, AdoRepository>();
-        }
-
-        return services;
-    }
+    return services;
+  }
 }

--- a/src/Acontplus.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/src/Acontplus.Persistence.PostgreSQL/Interceptors/AuditSaveChangesInterceptor.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Acontplus.Persistence.PostgreSQL.Interceptors;
+
+/// <summary>
+/// A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+/// <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+/// <see cref="BaseEntity"/> before changes are persisted.
+/// </summary>
+/// <remarks>
+/// Registered automatically by <c>AddPostgresPersistence</c>.  Resolves
+/// <see cref="IAuditContext"/> from a fresh DI scope on each save, so it is
+/// safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+/// </remarks>
+public sealed class AuditSaveChangesInterceptor(IServiceScopeFactory scopeFactory) : SaveChangesInterceptor
+{
+  /// <inheritdoc/>
+  public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+  {
+    Apply(eventData.Context);
+    return base.SavingChanges(eventData, result);
+  }
+
+  /// <inheritdoc/>
+  public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+      DbContextEventData eventData,
+      InterceptionResult<int> result,
+      CancellationToken cancellationToken = default)
+  {
+    Apply(eventData.Context);
+    return base.SavingChangesAsync(eventData, result, cancellationToken);
+  }
+
+  private void Apply(DbContext? context)
+  {
+    if (context is null) return;
+
+    using var scope = scopeFactory.CreateScope();
+    var auditContext = scope.ServiceProvider.GetService<IAuditContext>();
+    if (auditContext is null) return;
+
+    foreach (var entry in context.ChangeTracker.Entries<BaseEntity>())
+    {
+      switch (entry.State)
+      {
+        case EntityState.Added:
+          entry.Entity.CreatedByUserId = auditContext.UserId;
+          entry.Entity.CreatedBy = auditContext.UserName;
+          entry.Entity.IsMobileRequest = auditContext.IsMobile;
+          break;
+
+        case EntityState.Modified:
+          entry.Entity.UpdatedByUserId = auditContext.UserId;
+          entry.Entity.UpdatedBy = auditContext.UserName;
+          if (entry.Entity.IsDeleted && entry.Entity.DeletedBy is null)
+          {
+            entry.Entity.DeletedByUserId = auditContext.UserId;
+            entry.Entity.DeletedBy = auditContext.UserName;
+          }
+          break;
+      }
+    }
+  }
+}

--- a/src/Acontplus.Persistence.PostgreSQL/README.md
+++ b/src/Acontplus.Persistence.PostgreSQL/README.md
@@ -16,6 +16,7 @@ PostgreSQL implementation of the Acontplus persistence layer. Provides optimized
 - **Dapper Integration** - Lightweight micro-ORM for complex queries with automatic object mapping
 - **COPY Command Integration** - Optimized bulk inserts with NpgsqlBinaryImporter
 - **Streaming Queries** - Memory-efficient `IAsyncEnumerable<T>` for large datasets
+- **Automatic Audit Stamping** - `AuditSaveChangesInterceptor` auto-populates `CreatedBy`, `UpdatedBy`, `DeletedBy` (and their `UserId` counterparts) on every `BaseEntity` via `IAuditContext`, singleton-safe with `AddDbContextPool`
 - **JSON/JSONB Support** - Native JSON operations and indexing
 - **Array Types** - PostgreSQL array type handling and operations
 - **Full-Text Search** - PostgreSQL full-text search integration
@@ -25,16 +26,19 @@ PostgreSQL implementation of the Acontplus persistence layer. Provides optimized
 ## 📦 Installation
 
 ### NuGet Package Manager
+
 ```bash
 Install-Package Acontplus.Persistence.PostgreSQL
 ```
 
 ### .NET CLI
+
 ```bash
 dotnet add package Acontplus.Persistence.PostgreSQL
 ```
 
 ### PackageReference
+
 ```xml
 <ItemGroup>
   <PackageReference Include="Acontplus.Persistence.PostgreSQL" Version="x.x.x" />
@@ -47,13 +51,17 @@ dotnet add package Acontplus.Persistence.PostgreSQL
 ### 1. Configure PostgreSQL Persistence
 
 ```csharp
-// Option 1: Full EF Core with UnitOfWork (includes IAdoRepository automatically)
+// Option 1: Full EF Core with UnitOfWork (includes IAdoRepository and audit interceptor automatically)
 services.AddPostgresPersistence<MyDbContext>(options =>
     options.UseNpgsql(connectionString, npgsqlOptions =>
     {
         npgsqlOptions.EnableRetryOnFailure(3, TimeSpan.FromSeconds(30), null);
         npgsqlOptions.CommandTimeout(60);
     }));
+
+// Register your IAuditContext implementation so the interceptor can resolve audit info
+// (optional — stamping is skipped when IAuditContext is not registered)
+services.AddScoped<IAuditContext, HttpContextAuditContext>();
 
 // Option 2: Add Dapper alongside EF Core (for complex queries)
 services.AddPostgresPersistence<MyDbContext>(options => options.UseNpgsql(connectionString));
@@ -71,6 +79,7 @@ services.Configure<PersistenceResilienceOptions>(
 ```
 
 ### 2. Entity Framework Repository Pattern
+
 ```csharp
 public class UserService
 {
@@ -94,6 +103,7 @@ public class UserService
 ### 3. High-Performance ADO.NET Operations
 
 #### Scalar Queries
+
 ```csharp
 public class OrderService
 {
@@ -128,6 +138,7 @@ public class OrderService
 ```
 
 #### Pagination with Security
+
 ```csharp
 // Using PaginationDto from Acontplus.Core
 public async Task<PagedResult<Order>> GetPagedOrdersAsync(PaginationDto pagination)
@@ -175,6 +186,7 @@ public async Task<PagedResult<User>> GetPagedUsersFromFunctionAsync(
 ```
 
 #### Bulk Operations (100,000+ records/sec with COPY)
+
 ```csharp
 // PostgreSQL COPY command with DataTable
 public async Task<int> BulkInsertOrdersAsync(List<Order> orders)
@@ -219,6 +231,7 @@ public async Task<int> BulkInsertProductsAsync(IEnumerable<Product> products)
 ```
 
 #### Streaming Large Datasets
+
 ```csharp
 // Memory-efficient CSV export with IAsyncEnumerable
 public async Task ExportOrdersToCsvAsync(StreamWriter writer)
@@ -257,6 +270,7 @@ public async Task ProcessLargeOrderBatchAsync()
 ```
 
 #### Batch and Multi-Result Queries
+
 ```csharp
 // Execute multiple commands in one transaction
 public async Task<int> ExecuteBatchUpdatesAsync(List<int> orderIds)
@@ -344,6 +358,7 @@ public class ReportService
 ```
 
 ### 5. Advanced EF Core Query Operations
+
 ```csharp
 // Complex queries with PostgreSQL optimizations
 public async Task<IReadOnlyList<OrderSummary>> GetOrderSummariesAsync(
@@ -371,6 +386,7 @@ public async Task<IReadOnlyList<OrderSummary>> GetOrderSummariesAsync(
 ## 🔧 PostgreSQL Configuration
 
 ### Connection String Best Practices
+
 ```json
 {
   "ConnectionStrings": {
@@ -380,8 +396,11 @@ public async Task<IReadOnlyList<OrderSummary>> GetOrderSummariesAsync(
 ```
 
 ### Performance Tuning
+
 ```csharp
-services.AddDbContext<BaseContext>(options =>
+// Use AddPostgresPersistence — this wires the AuditSaveChangesInterceptor automatically.
+// Do NOT use AddDbContext directly; it bypasses the interceptor registration.
+services.AddPostgresPersistence<MyDbContext>(options =>
 {
     options.UseNpgsql(connectionString, npgsqlOptions =>
     {
@@ -405,11 +424,13 @@ services.AddDbContext<BaseContext>(options =>
 ## 📚 PostgreSQL API Reference
 
 ### Entity Framework Repositories
+
 - `BaseContext` - Optimized EF Core context for PostgreSQL
 - `IRepository<TEntity>` - Generic repository pattern with change tracking
 - `BaseRepository<TEntity>` - EF Core implementation with query optimization
 
 ### ADO.NET High-Performance Repositories
+
 - `IAdoRepository` - Interface for direct ADO.NET operations
 - `AdoRepository` - PostgreSQL-optimized implementation with:
   - **Scalar Queries**: `ExecuteScalarAsync<T>`, `ExistsAsync`, `CountAsync`, `LongCountAsync`
@@ -420,11 +441,26 @@ services.AddDbContext<BaseContext>(options =>
   - **Functions/Procedures**: `GetPagedFromStoredProcedureAsync<T>` with OUTPUT parameters
 
 ### Security & Error Handling
+
 - `PostgreSqlExceptionHandler` - Maps PostgreSQL error codes to domain exceptions
 - `ValidateAndSanitizeSortColumn` - SQL injection prevention (regex `^[a-zA-Z0-9_\.]+$` + keyword blacklist)
 - `AsyncRetryPolicy` - Polly integration with 3 retries and exponential backoff
 
+### EF Core Interceptors
+
+- `AuditSaveChangesInterceptor` - Singleton registered automatically by `AddPostgresPersistence`. Before every save it creates a fresh DI scope, resolves `IAuditContext`, and stamps:
+  - `CreatedByUserId` / `CreatedBy` / `IsMobileRequest` on `Added` entities
+  - `UpdatedByUserId` / `UpdatedBy` on `Modified` entities
+  - `DeletedByUserId` / `DeletedBy` on soft-deleted (`IsDeleted = true`) `Modified` entities
+
+  Audit stamping is silently skipped when `IAuditContext` is not registered.
+
+  **Why `CreateScope()` per save instead of constructor injection?** `AddDbContextPool` reuses context instances across requests without re-running constructors. If `IAuditContext` were injected in the constructor it would capture the first request's user and stamp all subsequent requests incorrectly. `CreateScope()` resolves a fresh `IAuditContext` on every save, always capturing the current request's identity — the only correct approach with pooling.
+
+  **High-concurrency overhead**: `IServiceScopeFactory.CreateScope()` is allocation-only (no locks, no I/O). Under 10k concurrent writes/sec the extra cost is ~1–3μs per save and negligible Gen0 GC pressure.
+
 ### PostgreSQL-Specific Features
+
 - `DbDataReaderMapper` - Fast mapping from DbDataReader to entities/DTOs
 - `NpgsqlBinaryImporter` - Ultra-fast bulk insert with COPY command
 - `CommandParameterBuilder` - Type-safe parameter builder
@@ -435,6 +471,7 @@ services.AddDbContext<BaseContext>(options =>
 ## 🔐 Security Features
 
 ### SQL Injection Prevention
+
 ```csharp
 // Automatic validation of sort columns
 var pagination = new PaginationDto
@@ -448,6 +485,7 @@ var pagination = new PaginationDto
 ```
 
 ### Metadata Exposure Control
+
 ```csharp
 // PaginationMetadataOptions controls what metadata is exposed
 services.Configure<PaginationMetadataOptions>(options =>
@@ -459,19 +497,20 @@ services.Configure<PaginationMetadataOptions>(options =>
 
 ## ⚡ Performance Benchmarks
 
-| Operation | EF Core | ADO.NET (COPY) | Performance Gain |
-|-----------|---------|----------------|------------------|
-| Simple Query (1,000 rows) | 48ms | 14ms | **3.43x faster** |
-| Pagination (10,000 rows) | 195ms | 42ms | **4.64x faster** |
-| Bulk Insert (10,000 rows) | 9,200ms | 320ms | **28.75x faster** |
-| Bulk Insert (100,000 rows) | 98,000ms | 2,800ms | **35x faster** |
-| Streaming Export (1M rows) | OutOfMemory | 3.8s | **Memory efficient** |
+| Operation                  | EF Core     | ADO.NET (COPY) | Performance Gain     |
+| -------------------------- | ----------- | -------------- | -------------------- |
+| Simple Query (1,000 rows)  | 48ms        | 14ms           | **3.43x faster**     |
+| Pagination (10,000 rows)   | 195ms       | 42ms           | **4.64x faster**     |
+| Bulk Insert (10,000 rows)  | 9,200ms     | 320ms          | **28.75x faster**    |
+| Bulk Insert (100,000 rows) | 98,000ms    | 2,800ms        | **35x faster**       |
+| Streaming Export (1M rows) | OutOfMemory | 3.8s           | **Memory efficient** |
 
 > **Note:** PostgreSQL COPY command significantly outperforms SqlBulkCopy for bulk operations
 
 ### When to Use Each Approach
 
 **Use EF Core (`IRepository<T>`) when:**
+
 - ✅ Complex object graphs with navigation properties
 - ✅ Change tracking is needed
 - ✅ LINQ query composition
@@ -480,6 +519,7 @@ services.Configure<PaginationMetadataOptions>(options =>
 - ✅ JSON/JSONB operations with entity mapping
 
 **Use ADO.NET (`IAdoRepository`) when:**
+
 - ✅ High-volume bulk operations (50,000+ records)
 - ✅ Simple DTOs or read-only queries
 - ✅ Custom SQL optimization required

--- a/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.csproj
+++ b/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Acontplus.Persistence.SqlServer</PackageId>
-    <Version>2.1.9</Version>
+    <Version>2.2.0</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.xml
+++ b/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.xml
@@ -204,14 +204,28 @@
         </member>
         <member name="T:Acontplus.Persistence.SqlServer.Context.BaseContext">
             <summary>
-            Base EF Core database context for SQL Server with support for domain events, auditing, and soft deletes.
+            Base EF Core database context for SQL Server with support for domain events, timestamp auditing, and soft deletes.
             </summary>
+            <remarks>
+            Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+            <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+            <see cref="T:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddSqlServerPersistence</c>.
+            This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+            hard-delete → soft-delete conversion.
+            </remarks>
             <param name="options">The options to be used by the DbContext.</param>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions)">
             <summary>
-            Base EF Core database context for SQL Server with support for domain events, auditing, and soft deletes.
+            Base EF Core database context for SQL Server with support for domain events, timestamp auditing, and soft deletes.
             </summary>
+            <remarks>
+            Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+            <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+            <see cref="T:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddSqlServerPersistence</c>.
+            This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+            hard-delete → soft-delete conversion.
+            </remarks>
             <param name="options">The options to be used by the DbContext.</param>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Domain.Common.Events.IDomainEventDispatcher)">
@@ -221,51 +235,37 @@
             <param name="options">The options to be used by the DbContext.</param>
             <param name="eventDispatcher">The domain event dispatcher.</param>
         </member>
-        <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Domain.Common.Events.IDomainEventDispatcher,Acontplus.Core.Abstractions.Context.IAuditContext)">
-            <summary>
-            Initializes a new instance with a domain event dispatcher and audit context.
-            </summary>
-            <param name="options">The options to be used by the DbContext.</param>
-            <param name="eventDispatcher">The domain event dispatcher.</param>
-            <param name="auditContext">The audit context for tracking user information.</param>
-        </member>
-        <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions,Acontplus.Core.Abstractions.Context.IAuditContext)">
-            <summary>
-            Initializes a new instance with an audit context.
-            </summary>
-            <param name="options">The options to be used by the DbContext.</param>
-            <param name="auditContext">The audit context for tracking user information.</param>
-        </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.SaveChangesAsync(System.Threading.CancellationToken)">
-            <summary>
-            Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes asynchronously.
-            </summary>
-            <param name="cancellationToken">A token to cancel the operation.</param>
-            <returns>The number of state entries written to the database.</returns>
+            <inheritdoc/>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.SaveChanges">
+            <inheritdoc/>
+        </member>
+        <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.UpdateTimestamps">
             <summary>
-            Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes synchronously.
+            Stamps <c>CreatedAt</c> on added entities and <c>UpdatedAt</c> on modified entities.
+            User-identity fields are handled by <see cref="T:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>.
             </summary>
-            <returns>The number of state entries written to the database.</returns>
+        </member>
+        <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.HandleSoftDeletes">
+            <summary>
+            Converts hard-deletes into soft-deletes and handles restore logic.
+            User-identity fields on deletion (<c>DeletedBy</c>, <c>DeletedByUserId</c>) are handled
+            by <see cref="T:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>.
+            </summary>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.OnModelCreating(Microsoft.EntityFrameworkCore.ModelBuilder)">
-            <summary>
-            Configures the model by applying global soft-delete filters, date-time conversions, and SQL Server-specific settings.
-            </summary>
-            <param name="modelBuilder">The model builder used to construct the model for the context.</param>
+            <inheritdoc/>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.ConfigureDateTimeProperties(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <summary>
             Applies UTC-aware value converters to all <see cref="T:System.DateTime"/> and nullable DateTime properties.
             </summary>
-            <param name="builder">The model builder.</param>
         </member>
         <member name="M:Acontplus.Persistence.SqlServer.Context.BaseContext.ApplySqlServerConfigurations(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <summary>
             Applies SQL Server-specific model configurations such as decimal precision and non-Unicode string mappings.
             </summary>
-            <param name="builder">The model builder.</param>
         </member>
         <member name="T:Acontplus.Persistence.SqlServer.DependencyInjection.SqlServerServiceCollectionExtensions">
             <summary>
@@ -388,6 +388,36 @@
                 The exception that is the cause of the current exception, or a null reference
                 (Nothing in Visual Basic) if no inner exception is specified.
             </param>
+        </member>
+        <member name="T:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor">
+            <summary>
+            A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+            <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+            <see cref="T:Acontplus.Core.Domain.Common.Entities.BaseEntity"/> before changes are persisted.
+            </summary>
+            <remarks>
+            Registered automatically by <c>AddSqlServerPersistence</c>.  Resolves
+            <see cref="T:Acontplus.Core.Abstractions.Context.IAuditContext"/> from a fresh DI scope on each save, so it is
+            safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+            </remarks>
+        </member>
+        <member name="M:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor.#ctor(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory)">
+            <summary>
+            A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+            <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+            <see cref="T:Acontplus.Core.Domain.Common.Entities.BaseEntity"/> before changes are persisted.
+            </summary>
+            <remarks>
+            Registered automatically by <c>AddSqlServerPersistence</c>.  Resolves
+            <see cref="T:Acontplus.Core.Abstractions.Context.IAuditContext"/> from a fresh DI scope on each save, so it is
+            safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+            </remarks>
+        </member>
+        <member name="M:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor.SavingChanges(Microsoft.EntityFrameworkCore.Diagnostics.DbContextEventData,Microsoft.EntityFrameworkCore.Diagnostics.InterceptionResult{System.Int32})">
+            <inheritdoc/>
+        </member>
+        <member name="M:Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor.SavingChangesAsync(Microsoft.EntityFrameworkCore.Diagnostics.DbContextEventData,Microsoft.EntityFrameworkCore.Diagnostics.InterceptionResult{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc/>
         </member>
         <member name="T:Acontplus.Persistence.SqlServer.Mapping.DataTableNameMapper">
             <summary>

--- a/src/Acontplus.Persistence.SqlServer/Context/BaseContext.cs
+++ b/src/Acontplus.Persistence.SqlServer/Context/BaseContext.cs
@@ -5,277 +5,214 @@ namespace Acontplus.Persistence.SqlServer.Context;
 /// </summary>
 public class SqlServerModelBuilderOptions
 {
-    /// <summary>Gets or sets a value indicating whether decimal precision/scale conversion is applied. Defaults to <c>true</c>.</summary>
-    public bool EnableDecimalConversion { get; set; } = true;
-    /// <summary>Gets or sets a value indicating whether string properties are mapped as non-Unicode. Defaults to <c>true</c>.</summary>
-    public bool EnableNonUnicodeStrings { get; set; } = true;
+  /// <summary>Gets or sets a value indicating whether decimal precision/scale conversion is applied. Defaults to <c>true</c>.</summary>
+  public bool EnableDecimalConversion { get; set; } = true;
+  /// <summary>Gets or sets a value indicating whether string properties are mapped as non-Unicode. Defaults to <c>true</c>.</summary>
+  public bool EnableNonUnicodeStrings { get; set; } = true;
 }
 
 /// <summary>
-/// Base EF Core database context for SQL Server with support for domain events, auditing, and soft deletes.
+/// Base EF Core database context for SQL Server with support for domain events, timestamp auditing, and soft deletes.
 /// </summary>
+/// <remarks>
+/// Audit identity fields (<c>CreatedBy</c>, <c>CreatedByUserId</c>, <c>UpdatedBy</c>, <c>UpdatedByUserId</c>,
+/// <c>DeletedBy</c>, <c>DeletedByUserId</c>, <c>IsMobileRequest</c>) are populated automatically by
+/// <see cref="Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>, which is registered as a singleton by <c>AddSqlServerPersistence</c>.
+/// This context only manages timestamps (<c>CreatedAt</c>, <c>UpdatedAt</c>, <c>DeletedAt</c>) and the
+/// hard-delete → soft-delete conversion.
+/// </remarks>
 /// <param name="options">The options to be used by the DbContext.</param>
 public abstract class BaseContext(DbContextOptions options) : DbContext(options)
 {
-    private readonly IDomainEventDispatcher? _eventDispatcher;
-    private readonly SqlServerModelBuilderOptions _sqlServerOptions = new();
-    private readonly IAuditContext? _auditContext;
+  private readonly IDomainEventDispatcher? _eventDispatcher;
+  private readonly SqlServerModelBuilderOptions _sqlServerOptions = new();
 
-    /// <summary>
-    /// Initializes a new instance with a domain event dispatcher.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="eventDispatcher">The domain event dispatcher.</param>
-    protected BaseContext(DbContextOptions options, IDomainEventDispatcher eventDispatcher)
-        : this(options)
+  /// <summary>
+  /// Initializes a new instance with a domain event dispatcher.
+  /// </summary>
+  /// <param name="options">The options to be used by the DbContext.</param>
+  /// <param name="eventDispatcher">The domain event dispatcher.</param>
+  protected BaseContext(DbContextOptions options, IDomainEventDispatcher eventDispatcher)
+    : this(options)
+  {
+    _eventDispatcher = eventDispatcher;
+  }
+
+  /// <inheritdoc/>
+  public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  {
+    await DispatchDomainEventsAsync();
+    UpdateTimestamps();
+    HandleSoftDeletes();
+    return await base.SaveChangesAsync(cancellationToken);
+  }
+
+  /// <inheritdoc/>
+  public override int SaveChanges()
+  {
+    DispatchDomainEventsAsync().GetAwaiter().GetResult();
+    UpdateTimestamps();
+    HandleSoftDeletes();
+    return base.SaveChanges();
+  }
+
+  private async Task DispatchDomainEventsAsync()
+  {
+    if (_eventDispatcher is null) return;
+
+    var entitiesWithEvents = ChangeTracker
+      .Entries<IEntityWithDomainEvents>()
+      .Where(e => e.Entity.DomainEvents.Any())
+      .Select(e => e.Entity)
+      .ToList();
+
+    foreach (var entity in entitiesWithEvents)
     {
-        _eventDispatcher = eventDispatcher;
+      var events = entity.DomainEvents.ToArray();
+      entity.ClearDomainEvents();
+      foreach (var domainEvent in events)
+        await _eventDispatcher.Dispatch(domainEvent);
     }
+  }
 
-    /// <summary>
-    /// Initializes a new instance with a domain event dispatcher and audit context.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="eventDispatcher">The domain event dispatcher.</param>
-    /// <param name="auditContext">The audit context for tracking user information.</param>
-    protected BaseContext(
-        DbContextOptions options,
-        IDomainEventDispatcher eventDispatcher,
-        IAuditContext auditContext)
-        : this(options, eventDispatcher)
+  /// <summary>
+  /// Stamps <c>CreatedAt</c> on added entities and <c>UpdatedAt</c> on modified entities.
+  /// User-identity fields are handled by <see cref="Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>.
+  /// </summary>
+  private void UpdateTimestamps()
+  {
+    foreach (var entry in ChangeTracker.Entries<BaseEntity>()
+               .Where(e => e.State is EntityState.Added or EntityState.Modified))
     {
-        _auditContext = auditContext;
+      if (entry.State == EntityState.Added)
+        entry.Entity.CreatedAt = DateTime.UtcNow;
+      else
+        entry.Entity.UpdatedAt = DateTime.UtcNow;
     }
+  }
 
-    /// <summary>
-    /// Initializes a new instance with an audit context.
-    /// </summary>
-    /// <param name="options">The options to be used by the DbContext.</param>
-    /// <param name="auditContext">The audit context for tracking user information.</param>
-    protected BaseContext(DbContextOptions options, IAuditContext auditContext)
-        : this(options)
+  /// <summary>
+  /// Converts hard-deletes into soft-deletes and handles restore logic.
+  /// User-identity fields on deletion (<c>DeletedBy</c>, <c>DeletedByUserId</c>) are handled
+  /// by <see cref="Acontplus.Persistence.SqlServer.Interceptors.AuditSaveChangesInterceptor"/>.
+  /// </summary>
+  private void HandleSoftDeletes()
+  {
+    var entries = ChangeTracker.Entries<BaseEntity>()
+      .Where(e => e.State == EntityState.Deleted ||
+                  e.Property(nameof(BaseEntity.IsDeleted)).IsModified)
+      .ToList();
+
+    foreach (var entry in entries)
     {
-        _auditContext = auditContext;
+      var entity = entry.Entity;
+
+      if (entry.State == EntityState.Deleted || entity.IsDeleted)
+      {
+        // Convert hard-delete into a soft-delete
+        entry.State = EntityState.Modified;
+        entity.IsDeleted = true;
+        entity.IsActive = false;
+        entity.DeletedAt = DateTime.UtcNow;
+      }
+      else if (!entity.IsDeleted && entity.DeletedAt is not null)
+      {
+        // Restore from soft-delete — clear all deletion stamps
+        entity.DeletedAt = null;
+        entity.DeletedByUserId = null;
+        entity.DeletedBy = null;
+        entity.IsActive = true;
+        entity.UpdatedAt = DateTime.UtcNow;
+      }
     }
+  }
 
-    /// <summary>
-    /// Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes asynchronously.
-    /// </summary>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>The number of state entries written to the database.</returns>
-    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+  /// <inheritdoc/>
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    base.OnModelCreating(modelBuilder);
+
+    ConfigureGlobalFilters(modelBuilder);
+    ConfigureDateTimeProperties(modelBuilder);
+
+    if (Database.IsSqlServer())
+      ApplySqlServerConfigurations(modelBuilder);
+  }
+
+  private static void ConfigureGlobalFilters(ModelBuilder modelBuilder)
+  {
+    foreach (var entityType in modelBuilder.Model.GetEntityTypes())
     {
-        await DispatchDomainEventsAsync();
-        // Only update audit fields and handle soft deletes for auditable entities
-        await UpdateAuditFieldsAsync();
-        await HandleSoftDeletesAsync();
-
-        var result = await base.SaveChangesAsync(cancellationToken);
-        return result;
+      if (typeof(BaseEntity).IsAssignableFrom(entityType.ClrType))
+      {
+        var parameter = Expression.Parameter(entityType.ClrType, "e");
+        var property = Expression.Property(parameter, nameof(BaseEntity.IsDeleted));
+        var condition = Expression.Lambda(Expression.Not(property), parameter);
+        modelBuilder.Entity(entityType.ClrType).HasQueryFilter(condition);
+      }
     }
+  }
 
-    /// <summary>
-    /// Saves all changes, dispatches domain events, updates audit fields, and handles soft deletes synchronously.
-    /// </summary>
-    /// <returns>The number of state entries written to the database.</returns>
-    public override int SaveChanges()
+  /// <summary>
+  /// Applies UTC-aware value converters to all <see cref="DateTime"/> and nullable DateTime properties.
+  /// </summary>
+  protected virtual void ConfigureDateTimeProperties(ModelBuilder builder)
+  {
+    foreach (var entityType in builder.Model.GetEntityTypes())
     {
-        DispatchDomainEventsAsync().GetAwaiter().GetResult();
-        UpdateAuditFieldsAsync().GetAwaiter().GetResult();
-        HandleSoftDeletesAsync().GetAwaiter().GetResult();
-
-        return base.SaveChanges();
-    }
-
-    private async Task DispatchDomainEventsAsync()
-    {
-        if (_eventDispatcher == null)
+      foreach (var property in entityType.GetProperties()
+                 .Where(p => p.ClrType == typeof(DateTime) || p.ClrType == typeof(DateTime?)))
+      {
+        if (property.ClrType == typeof(DateTime))
         {
-            return;
+          builder.Entity(entityType.ClrType)
+            .Property<DateTime>(property.Name)
+            .HasConversion(
+              v => v.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(v, DateTimeKind.Utc)
+                : v.ToUniversalTime(),
+              v => v);
         }
-
-        var entitiesWithEvents = ChangeTracker
-            .Entries<IEntityWithDomainEvents>()
-            .Where(e => e.Entity.DomainEvents.Any())
-            .Select(e => e.Entity)
-            .ToList();
-
-        foreach (var entity in entitiesWithEvents)
+        else
         {
-            var events = entity.DomainEvents.ToArray();
-            entity.ClearDomainEvents();
-
-            foreach (var domainEvent in events)
-            {
-                await _eventDispatcher.Dispatch(domainEvent);
-            }
+          builder.Entity(entityType.ClrType)
+            .Property<DateTime?>(property.Name)
+            .HasConversion(
+              v => v.HasValue
+                ? v.Value.Kind == DateTimeKind.Unspecified
+                  ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                  : v.Value.ToUniversalTime()
+                : (DateTime?)null,
+              v => v);
         }
+      }
     }
+  }
 
-    private Task UpdateAuditFieldsAsync()
+  /// <summary>
+  /// Applies SQL Server-specific model configurations such as decimal precision and non-Unicode string mappings.
+  /// </summary>
+  protected virtual void ApplySqlServerConfigurations(ModelBuilder builder)
+  {
+    if (_sqlServerOptions.EnableDecimalConversion)
     {
-        var entries = ChangeTracker.Entries()
-            .Where(e => e.Entity is BaseEntity &&
-                        (e.State == EntityState.Added || e.State == EntityState.Modified))
-            .ToList();
-
-        foreach (var entry in entries)
-        {
-            var entity = (BaseEntity)entry.Entity;
-
-            if (entry.State == EntityState.Added)
-            {
-                entity.CreatedAt = DateTime.UtcNow;
-                entity.CreatedByUserId = _auditContext?.UserId;
-                entity.CreatedBy = _auditContext?.UserName;
-                entity.IsMobileRequest = _auditContext?.IsMobile ?? entity.IsMobileRequest;
-            }
-            else
-            {
-                entity.UpdatedAt = DateTime.UtcNow;
-                entity.UpdatedByUserId = _auditContext?.UserId;
-                entity.UpdatedBy = _auditContext?.UserName;
-            }
-        }
-
-        return Task.CompletedTask;
+      foreach (var property in builder.Model.GetEntityTypes()
+                 .SelectMany(t => t.GetProperties())
+                 .Where(p => p.ClrType == typeof(decimal) || p.ClrType == typeof(decimal?)))
+      {
+        property.SetPrecision(18);
+        property.SetScale(2);
+      }
     }
 
-    private Task HandleSoftDeletesAsync()
+    if (_sqlServerOptions.EnableNonUnicodeStrings)
     {
-        var entries = ChangeTracker.Entries()
-            .Where(e => e.Entity is BaseEntity &&
-                        (e.State == EntityState.Deleted ||
-                         e.Property(nameof(BaseEntity.IsDeleted)).IsModified))
-            .ToList();
-
-        foreach (var entry in entries)
-        {
-            var entity = (BaseEntity)entry.Entity;
-
-            if (entry.State == EntityState.Deleted || entity.IsDeleted)
-            {
-                // Convert hard-delete into a soft-delete
-                entry.State = EntityState.Modified;
-                entity.IsDeleted = true;
-                entity.IsActive = false;
-                entity.DeletedAt = DateTime.UtcNow;
-                entity.DeletedByUserId = _auditContext?.UserId;
-                entity.DeletedBy = _auditContext?.UserName;
-            }
-            else if (!entity.IsDeleted && entity.DeletedAt is not null)
-            {
-                // Restore from soft-delete — clear all deletion stamps
-                entity.DeletedAt = null;
-                entity.DeletedByUserId = null;
-                entity.DeletedBy = null;
-                entity.IsActive = true;
-                entity.UpdatedAt = DateTime.UtcNow;
-                entity.UpdatedByUserId = _auditContext?.UserId;
-                entity.UpdatedBy = _auditContext?.UserName;
-            }
-        }
-
-        return Task.CompletedTask;
+      foreach (var property in builder.Model.GetEntityTypes()
+                 .SelectMany(t => t.GetProperties())
+                 .Where(p => p.ClrType == typeof(string) && p.GetColumnType() == null))
+      {
+        property.SetIsUnicode(false);
+      }
     }
-
-    /// <summary>
-    /// Configures the model by applying global soft-delete filters, date-time conversions, and SQL Server-specific settings.
-    /// </summary>
-    /// <param name="modelBuilder">The model builder used to construct the model for the context.</param>
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-
-        ConfigureGlobalFilters(modelBuilder);
-        ConfigureDateTimeProperties(modelBuilder);
-
-        if (Database.IsSqlServer())
-        {
-            ApplySqlServerConfigurations(modelBuilder);
-        }
-    }
-
-    private static void ConfigureGlobalFilters(ModelBuilder modelBuilder)
-    {
-        // Only apply soft delete filter to auditable entities
-        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
-        {
-            if (typeof(BaseEntity).IsAssignableFrom(entityType.ClrType))
-            {
-                var parameter = Expression.Parameter(entityType.ClrType, "e");
-                var property = Expression.Property(parameter, nameof(BaseEntity.IsDeleted));
-                var condition = Expression.Lambda(Expression.Not(property), parameter);
-
-                modelBuilder.Entity(entityType.ClrType).HasQueryFilter(condition);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Applies UTC-aware value converters to all <see cref="DateTime"/> and nullable DateTime properties.
-    /// </summary>
-    /// <param name="builder">The model builder.</param>
-    protected virtual void ConfigureDateTimeProperties(ModelBuilder builder)
-    {
-        foreach (var entityType in builder.Model.GetEntityTypes())
-        {
-            foreach (var property in entityType.GetProperties()
-                         .Where(p => p.ClrType == typeof(DateTime) || p.ClrType == typeof(DateTime?)))
-            {
-                if (property.ClrType == typeof(DateTime))
-                {
-                    builder.Entity(entityType.ClrType)
-                        .Property<DateTime>(property.Name)
-                        .HasConversion(
-                            v => v.Kind == DateTimeKind.Unspecified
-                                ? DateTime.SpecifyKind(v, DateTimeKind.Utc)
-                                : v.ToUniversalTime(),
-                            v => v
-                        );
-                }
-                else
-                {
-                    builder.Entity(entityType.ClrType)
-                        .Property<DateTime?>(property.Name)
-                        .HasConversion(
-                            v => v.HasValue
-                                ? v.Value.Kind == DateTimeKind.Unspecified
-                                    ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
-                                    : v.Value.ToUniversalTime()
-                                : (DateTime?)null,
-                            v => v
-                        );
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Applies SQL Server-specific model configurations such as decimal precision and non-Unicode string mappings.
-    /// </summary>
-    /// <param name="builder">The model builder.</param>
-    protected virtual void ApplySqlServerConfigurations(ModelBuilder builder)
-    {
-        if (_sqlServerOptions.EnableDecimalConversion)
-        {
-            foreach (var property in builder.Model.GetEntityTypes()
-                         .SelectMany(t => t.GetProperties())
-                         .Where(p => p.ClrType == typeof(decimal) || p.ClrType == typeof(decimal?)))
-            {
-                property.SetPrecision(18);
-                property.SetScale(2);
-            }
-        }
-
-        if (_sqlServerOptions.EnableNonUnicodeStrings)
-        {
-            foreach (var property in builder.Model.GetEntityTypes()
-                         .SelectMany(t => t.GetProperties())
-                         .Where(p => p.ClrType == typeof(string) && p.GetColumnType() == null))
-            {
-                property.SetIsUnicode(false);
-            }
-        }
-    }
+  }
 }

--- a/src/Acontplus.Persistence.SqlServer/DependencyInjection/SqlServerServiceCollectionExtensions.cs
+++ b/src/Acontplus.Persistence.SqlServer/DependencyInjection/SqlServerServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Acontplus.Persistence.Common.Configuration;
+using Acontplus.Persistence.SqlServer.Interceptors;
 using Acontplus.Persistence.SqlServer.Repositories;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -9,102 +10,108 @@ namespace Acontplus.Persistence.SqlServer.DependencyInjection;
 /// </summary>
 public static class SqlServerServiceCollectionExtensions
 {
-    /// <summary>
-    /// Ensures PersistenceResilienceOptions is registered with default values.
-    /// Called internally by persistence registration methods.
-    /// To configure from appsettings.json, add this in your Startup/Program.cs:
-    /// services.Configure&lt;PersistenceResilienceOptions&gt;(configuration.GetSection("Persistence:Resilience"));
-    /// </summary>
-    private static void EnsureResilienceOptionsRegistered(IServiceCollection services)
+  /// <summary>
+  /// Ensures PersistenceResilienceOptions is registered with default values.
+  /// Called internally by persistence registration methods.
+  /// To configure from appsettings.json, add this in your Startup/Program.cs:
+  /// services.Configure&lt;PersistenceResilienceOptions&gt;(configuration.GetSection("Persistence:Resilience"));
+  /// </summary>
+  private static void EnsureResilienceOptionsRegistered(IServiceCollection services)
+  {
+    services.TryAddSingleton<Microsoft.Extensions.Options.IOptions<PersistenceResilienceOptions>>(
+        sp => Microsoft.Extensions.Options.Options.Create(new PersistenceResilienceOptions()));
+  }
+
+  /// <summary>
+  ///     Registers a SQL Server DbContext and its corresponding UnitOfWork implementation,
+  ///     optionally with a service key using .NET 8+ keyed DI.
+  ///     Also registers IAdoRepository which is required by UnitOfWork.
+  /// </summary>
+  /// <typeparam name="TContext">The DbContext type to register.</typeparam>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="sqlServerOptions">The SQL Server-specific options for DbContext.</param>
+  /// <param name="serviceKey">Optional key to register the services with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddSqlServerPersistence<TContext>(
+      this IServiceCollection services,
+      Action<DbContextOptionsBuilder> sqlServerOptions,
+      object? serviceKey = null)
+      where TContext : DbContext
+  {
+    services.TryAddSingleton<AuditSaveChangesInterceptor>();
+
+    services.AddDbContextPool<TContext>((sp, options) =>
     {
-        services.TryAddSingleton<Microsoft.Extensions.Options.IOptions<PersistenceResilienceOptions>>(
-            sp => Microsoft.Extensions.Options.Options.Create(new PersistenceResilienceOptions()));
+      sqlServerOptions(options);
+      options.AddInterceptors(sp.GetRequiredService<AuditSaveChangesInterceptor>());
+    }, 128);
+
+    EnsureResilienceOptionsRegistered(services);
+
+    // Register IAdoRepository which is required by UnitOfWork
+    if (serviceKey is not null)
+    {
+      services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
+      services.TryAddKeyedScoped<IUnitOfWork, UnitOfWork<TContext>>(serviceKey);
+      services.TryAddKeyedScoped<DbContext>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<TContext>(key));
+    }
+    else
+    {
+      services.TryAddScoped<IAdoRepository, AdoRepository>();
+      services.TryAddScoped<IUnitOfWork, UnitOfWork<TContext>>();
+      services.TryAddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
     }
 
-    /// <summary>
-    ///     Registers a SQL Server DbContext and its corresponding UnitOfWork implementation,
-    ///     optionally with a service key using .NET 8+ keyed DI.
-    ///     Also registers IAdoRepository which is required by UnitOfWork.
-    /// </summary>
-    /// <typeparam name="TContext">The DbContext type to register.</typeparam>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="sqlServerOptions">The SQL Server-specific options for DbContext.</param>
-    /// <param name="serviceKey">Optional key to register the services with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddSqlServerPersistence<TContext>(
-        this IServiceCollection services,
-        Action<DbContextOptionsBuilder> sqlServerOptions,
-        object? serviceKey = null)
-        where TContext : DbContext
+    return services;
+  }
+
+  /// <summary>
+  /// Registers the Dapper repository for SQL Server with resilience policies.
+  /// Can be used independently or alongside Entity Framework Core.
+  /// </summary>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddSqlServerDapperRepository(
+      this IServiceCollection services,
+      object? serviceKey = null)
+  {
+    EnsureResilienceOptionsRegistered(services);
+
+    if (serviceKey is not null)
     {
-        services.AddDbContextPool<TContext>(sqlServerOptions, 128);
-
-        EnsureResilienceOptionsRegistered(services);
-
-        // Register IAdoRepository which is required by UnitOfWork
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
-            services.TryAddKeyedScoped<IUnitOfWork, UnitOfWork<TContext>>(serviceKey);
-            services.TryAddKeyedScoped<DbContext>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<TContext>(key));
-        }
-        else
-        {
-            services.TryAddScoped<IAdoRepository, AdoRepository>();
-            services.TryAddScoped<IUnitOfWork, UnitOfWork<TContext>>();
-            services.TryAddScoped<DbContext>(sp => sp.GetRequiredService<TContext>());
-        }
-
-        return services;
+      services.TryAddKeyedScoped<IDapperRepository, DapperRepository>(serviceKey);
+    }
+    else
+    {
+      services.TryAddScoped<IDapperRepository, DapperRepository>();
     }
 
-    /// <summary>
-    /// Registers the Dapper repository for SQL Server with resilience policies.
-    /// Can be used independently or alongside Entity Framework Core.
-    /// </summary>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddSqlServerDapperRepository(
-        this IServiceCollection services,
-        object? serviceKey = null)
+    return services;
+  }
+
+  /// <summary>
+  /// Registers the ADO.NET repository for SQL Server with resilience policies.
+  /// Can be used independently or alongside Entity Framework Core.
+  /// </summary>
+  /// <param name="services">The IServiceCollection.</param>
+  /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
+  /// <returns>The updated IServiceCollection.</returns>
+  public static IServiceCollection AddSqlServerAdoRepository(
+      this IServiceCollection services,
+      object? serviceKey = null)
+  {
+    EnsureResilienceOptionsRegistered(services);
+
+    if (serviceKey is not null)
     {
-        EnsureResilienceOptionsRegistered(services);
-
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IDapperRepository, DapperRepository>(serviceKey);
-        }
-        else
-        {
-            services.TryAddScoped<IDapperRepository, DapperRepository>();
-        }
-
-        return services;
+      services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
+    }
+    else
+    {
+      services.TryAddScoped<IAdoRepository, AdoRepository>();
     }
 
-    /// <summary>
-    /// Registers the ADO.NET repository for SQL Server with resilience policies.
-    /// Can be used independently or alongside Entity Framework Core.
-    /// </summary>
-    /// <param name="services">The IServiceCollection.</param>
-    /// <param name="serviceKey">Optional key to register the service with (for keyed DI).</param>
-    /// <returns>The updated IServiceCollection.</returns>
-    public static IServiceCollection AddSqlServerAdoRepository(
-        this IServiceCollection services,
-        object? serviceKey = null)
-    {
-        EnsureResilienceOptionsRegistered(services);
-
-        if (serviceKey is not null)
-        {
-            services.TryAddKeyedScoped<IAdoRepository, AdoRepository>(serviceKey);
-        }
-        else
-        {
-            services.TryAddScoped<IAdoRepository, AdoRepository>();
-        }
-
-        return services;
-    }
+    return services;
+  }
 }

--- a/src/Acontplus.Persistence.SqlServer/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/src/Acontplus.Persistence.SqlServer/Interceptors/AuditSaveChangesInterceptor.cs
@@ -1,0 +1,64 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Acontplus.Persistence.SqlServer.Interceptors;
+
+/// <summary>
+/// A singleton EF Core interceptor that populates audit fields (<c>CreatedBy</c>,
+/// <c>UpdatedBy</c>, <c>DeletedBy</c> and their UserId counterparts) on every
+/// <see cref="BaseEntity"/> before changes are persisted.
+/// </summary>
+/// <remarks>
+/// Registered automatically by <c>AddSqlServerPersistence</c>.  Resolves
+/// <see cref="IAuditContext"/> from a fresh DI scope on each save, so it is
+/// safe to use with <c>AddDbContextPool</c> (singleton-compatible).
+/// </remarks>
+public sealed class AuditSaveChangesInterceptor(IServiceScopeFactory scopeFactory) : SaveChangesInterceptor
+{
+  /// <inheritdoc/>
+  public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+  {
+    Apply(eventData.Context);
+    return base.SavingChanges(eventData, result);
+  }
+
+  /// <inheritdoc/>
+  public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+      DbContextEventData eventData,
+      InterceptionResult<int> result,
+      CancellationToken cancellationToken = default)
+  {
+    Apply(eventData.Context);
+    return base.SavingChangesAsync(eventData, result, cancellationToken);
+  }
+
+  private void Apply(DbContext? context)
+  {
+    if (context is null) return;
+
+    using var scope = scopeFactory.CreateScope();
+    var auditContext = scope.ServiceProvider.GetService<IAuditContext>();
+    if (auditContext is null) return;
+
+    foreach (var entry in context.ChangeTracker.Entries<BaseEntity>())
+    {
+      switch (entry.State)
+      {
+        case EntityState.Added:
+          entry.Entity.CreatedByUserId = auditContext.UserId;
+          entry.Entity.CreatedBy = auditContext.UserName;
+          entry.Entity.IsMobileRequest = auditContext.IsMobile;
+          break;
+
+        case EntityState.Modified:
+          entry.Entity.UpdatedByUserId = auditContext.UserId;
+          entry.Entity.UpdatedBy = auditContext.UserName;
+          if (entry.Entity.IsDeleted && entry.Entity.DeletedBy is null)
+          {
+            entry.Entity.DeletedByUserId = auditContext.UserId;
+            entry.Entity.DeletedBy = auditContext.UserName;
+          }
+          break;
+      }
+    }
+  }
+}

--- a/src/Acontplus.Persistence.SqlServer/README.md
+++ b/src/Acontplus.Persistence.SqlServer/README.md
@@ -8,7 +8,7 @@ SQL Server implementation of the Acontplus persistence layer. Provides optimized
 ADO.NET repositories, and SQL Server-specific features for high-performance data access.
 
 > **Note:** This package implements the abstractions defined in [**Acontplus.Persistence.Common
-**](https://www.nuget.org/packages/Acontplus.Persistence.Common). For general persistence patterns and repository
+> **](https://www.nuget.org/packages/Acontplus.Persistence.Common). For general persistence patterns and repository
 > interfaces, see the common package.
 
 ## 🚀 SQL Server-Specific Features
@@ -20,6 +20,7 @@ ADO.NET repositories, and SQL Server-specific features for high-performance data
 - **Dapper Integration** - Lightweight micro-ORM for complex queries with automatic object mapping
 - **SqlBulkCopy Integration** - Optimized bulk inserts with automatic column mapping
 - **Streaming Queries** - Memory-efficient `IAsyncEnumerable<T>` for large datasets
+- **Automatic Audit Stamping** - `AuditSaveChangesInterceptor` auto-populates `CreatedBy`, `UpdatedBy`, `DeletedBy` (and their `UserId` counterparts) on every `BaseEntity` via `IAuditContext`, singleton-safe with `AddDbContextPool`
 - **SQL Injection Prevention** - Regex validation and keyword blacklisting for dynamic queries
 - **Performance Monitoring** - Query execution statistics and performance insights
 
@@ -51,13 +52,17 @@ dotnet add package Acontplus.Persistence.SqlServer
 ### 1. Configure SQL Server Persistence
 
 ```csharp
-// Option 1: Full EF Core with UnitOfWork (includes IAdoRepository automatically)
+// Option 1: Full EF Core with UnitOfWork (includes IAdoRepository and audit interceptor automatically)
 services.AddSqlServerPersistence<MyDbContext>(options =>
     options.UseSqlServer(connectionString, sqlOptions =>
     {
         sqlOptions.EnableRetryOnFailure(3, TimeSpan.FromSeconds(30), null);
         sqlOptions.CommandTimeout(60);
     }));
+
+// Register your IAuditContext implementation so the interceptor can resolve audit info
+// (optional — stamping is skipped when IAuditContext is not registered)
+services.AddScoped<IAuditContext, HttpContextAuditContext>();
 
 // Option 2: Add Dapper alongside EF Core (for complex queries)
 services.AddSqlServerPersistence<MyDbContext>(options => options.UseSqlServer(connectionString));
@@ -395,7 +400,9 @@ public async Task<IReadOnlyList<OrderSummary>> GetOrderSummariesAsync(
 ### Performance Tuning
 
 ```csharp
-services.AddDbContext<BaseContext>(options =>
+// Use AddSqlServerPersistence — this wires the AuditSaveChangesInterceptor automatically.
+// Do NOT use AddDbContext directly; it bypasses the interceptor registration.
+services.AddSqlServerPersistence<MyDbContext>(options =>
 {
     options.UseSqlServer(connectionString, sqlOptions =>
     {
@@ -428,18 +435,31 @@ services.AddDbContext<BaseContext>(options =>
 
 - `IAdoRepository` - Interface for direct ADO.NET operations
 - `AdoRepository` - SQL Server optimized implementation with:
-    - **Scalar Queries**: `ExecuteScalarAsync<T>`, `ExistsAsync`, `CountAsync`, `LongCountAsync`
-    - **Pagination**: `GetPagedAsync<T>` with OFFSET-FETCH optimization
-    - **Bulk Operations**: `BulkInsertAsync` using SqlBulkCopy (10,000+ records/sec)
-    - **Streaming**: `QueryAsyncEnumerable<T>` for memory-efficient processing
-    - **Batch Operations**: `ExecuteBatchNonQueryAsync`, `QueryMultipleAsync<T>`
-    - **Stored Procedures**: `GetPagedFromStoredProcedureAsync<T>` with OUTPUT parameters
+  - **Scalar Queries**: `ExecuteScalarAsync<T>`, `ExistsAsync`, `CountAsync`, `LongCountAsync`
+  - **Pagination**: `GetPagedAsync<T>` with OFFSET-FETCH optimization
+  - **Bulk Operations**: `BulkInsertAsync` using SqlBulkCopy (10,000+ records/sec)
+  - **Streaming**: `QueryAsyncEnumerable<T>` for memory-efficient processing
+  - **Batch Operations**: `ExecuteBatchNonQueryAsync`, `QueryMultipleAsync<T>`
+  - **Stored Procedures**: `GetPagedFromStoredProcedureAsync<T>` with OUTPUT parameters
 
 ### Security & Error Handling
 
 - `SqlServerExceptionHandler` - Maps SQL Server error codes to domain exceptions
 - `ValidateAndSanitizeSortColumn` - SQL injection prevention (regex `^[a-zA-Z0-9_\.]+$` + keyword blacklist)
 - `AsyncRetryPolicy` - Polly integration with 3 retries and exponential backoff
+
+### EF Core Interceptors
+
+- `AuditSaveChangesInterceptor` - Singleton registered automatically by `AddSqlServerPersistence`. Before every save it creates a fresh DI scope, resolves `IAuditContext`, and stamps:
+  - `CreatedByUserId` / `CreatedBy` / `IsMobileRequest` on `Added` entities
+  - `UpdatedByUserId` / `UpdatedBy` on `Modified` entities
+  - `DeletedByUserId` / `DeletedBy` on soft-deleted (`IsDeleted = true`) `Modified` entities
+
+  Audit stamping is silently skipped when `IAuditContext` is not registered.
+
+  **Why `CreateScope()` per save instead of constructor injection?** `AddDbContextPool` reuses context instances across requests without re-running constructors. If `IAuditContext` were injected in the constructor it would capture the first request's user and stamp all subsequent requests incorrectly. `CreateScope()` resolves a fresh `IAuditContext` on every save, always capturing the current request's identity — the only correct approach with pooling.
+
+  **High-concurrency overhead**: `IServiceScopeFactory.CreateScope()` is allocation-only (no locks, no I/O). Under 10k concurrent writes/sec the extra cost is ~1–3μs per save and negligible Gen0 GC pressure.
 
 ### Utilities
 
@@ -478,7 +498,7 @@ services.Configure<PaginationMetadataOptions>(options =>
 ## ⚡ Performance Benchmarks
 
 | Operation                  | EF Core     | ADO.NET | Performance Gain     |
-|----------------------------|-------------|---------|----------------------|
+| -------------------------- | ----------- | ------- | -------------------- |
 | Simple Query (1,000 rows)  | 45ms        | 12ms    | **3.75x faster**     |
 | Pagination (10,000 rows)   | 180ms       | 35ms    | **5.14x faster**     |
 | Bulk Insert (10,000 rows)  | 8,500ms     | 850ms   | **10x faster**       |


### PR DESCRIPTION
…erceptors

- Add `AuditSaveChangesInterceptor` to PostgreSQL and SqlServer persistence packages for automatic audit field stamping
- Remove `IAuditContext` dependency from `BaseContext` constructors; audit resolution now handled by interceptor via service scope
- Register `AuditSaveChangesInterceptor` as singleton in `AddPostgresPersistence` and `AddSqlServerPersistence` extension methods
- Update `BaseContext` to focus on timestamp management and soft-delete conversion; identity audit fields now populated by interceptor
- Bump Acontplus.Persistence.PostgreSQL to 1.4.0 and Acontplus.Persistence.SqlServer to 2.2.0
- Update XML documentation to reflect new audit architecture and interceptor responsibility
- Simplify demo `TestContext` constructor by removing explicit `IAuditContext` parameter
- Audit stamping gracefully no-ops when `IAuditContext` is not registered in DI; fully compatible with `AddDbContextPool`