### PR TITLE
ci: update GitHub Actions versions and standardize YAML formatting

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '10.0.x'
+  DOTNET_VERSION: "10.0.x"
   CONFIGURATION: Release
 
 # Cancel in-progress runs when new commits are pushed
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate package versions
         shell: pwsh
@@ -98,10 +98,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/cascade-publish.yml
+++ b/.github/workflows/cascade-publish.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       root-package:
-        description: 'Root package to update (e.g., Core, Utilities)'
+        description: "Root package to update (e.g., Core, Utilities)"
         required: true
         type: string
       bump-type:
-        description: 'Version bump type'
+        description: "Version bump type"
         required: true
         type: choice
         options:
@@ -17,7 +17,7 @@ on:
           - major
         default: patch
       cascade-bump:
-        description: 'Bump type for dependent packages'
+        description: "Bump type for dependent packages"
         required: true
         type: choice
         options:
@@ -26,18 +26,18 @@ on:
           - none
         default: patch
       run-tests:
-        description: 'Run tests before publishing'
+        description: "Run tests before publishing"
         required: false
         type: boolean
         default: true
       dry-run:
-        description: 'Dry run (no actual publish)'
+        description: "Dry run (no actual publish)"
         required: false
         type: boolean
         default: false
 
 env:
-  DOTNET_VERSION: '10.0.x'
+  DOTNET_VERSION: "10.0.x"
   CONFIGURATION: Release
 
 permissions:
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Calculate dependency order
         id: calculate
@@ -227,13 +227,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -586,7 +586,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.update-and-publish.outputs.branch-name }}
 
@@ -603,7 +603,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ github.run_number }}-cascade-${{ inputs.root-package }}
           name: 🔄 Cascade Release - ${{ inputs.root-package }}
@@ -621,7 +621,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Notify rollback needed
         shell: pwsh
@@ -643,7 +643,7 @@ jobs:
           Write-Host "================================================" -ForegroundColor Red
 
       - name: Create rollback issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = await github.rest.issues.create({

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:

--- a/.github/workflows/smart-publish.yml
+++ b/.github/workflows/smart-publish.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -180,10 +180,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Create cascade update issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const packages = JSON.parse('${{ needs.analyze-changes.outputs.changed-packages }}');
@@ -260,10 +260,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -379,7 +379,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -409,7 +409,7 @@ jobs:
           "tag=$tag" >> $env:GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.notes.outputs.tag }}
           name: 📦 Release - ${{ steps.notes.outputs.tag }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -3,11 +3,11 @@ name: Version Check
 on:
   schedule:
     # Run daily at 9 AM UTC
-    - cron: '0 9 * * *'
+    - cron: "0 9 * * *"
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '10.0.x'
+  DOTNET_VERSION: "10.0.x"
 
 jobs:
   check-versions:
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -141,7 +141,7 @@ jobs:
 
       - name: Create issue for unpublished packages
         if: steps.check-versions.outputs.has-unpublished == 'true' && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueTitle = '📦 Unpublished Package Versions Detected';

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Acontplus.Analytics" Version="1.0.0" />
-    <PackageVersion Include="Acontplus.Barcode" Version="1.2.6" />
+    <PackageVersion Include="Acontplus.Barcode" Version="1.2.7" />
     <PackageVersion Include="Acontplus.Core" Version="2.3.2" />
-    <PackageVersion Include="Acontplus.Persistence.Common" Version="2.1.2" />
-    <PackageVersion Include="Acontplus.Utilities" Version="2.1.1" />
+    <PackageVersion Include="Acontplus.Persistence.Common" Version="2.1.3" />
+    <PackageVersion Include="Acontplus.Utilities" Version="2.2.0" />
     <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
@@ -17,7 +17,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="AWSSDK.Core" Version="4.0.9.7" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.25.3" />
-    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.14" />
+    <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.0.14.9" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.2.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
@@ -49,12 +49,12 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
     <PackageVersion Include="Polly" Version="8.7.0" />
-    <PackageVersion Include="QuestPDF" Version="2026.5.0" />
+    <PackageVersion Include="QuestPDF" Version="2026.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="5.0.0" />
     <PackageVersion Include="ReportViewerCore.NETCore" Version="15.1.33" />
-    <PackageVersion Include="Scriban" Version="7.2.3" />
+    <PackageVersion Include="Scriban" Version="7.2.5" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -71,7 +71,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="ZXing.Net" Version="0.16.11" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.22" />
   </ItemGroup>

--- a/src/Acontplus.Analytics/Acontplus.Analytics.csproj
+++ b/src/Acontplus.Analytics/Acontplus.Analytics.csproj
@@ -8,7 +8,7 @@
     <Description>Analytics and statistics library for AcontPlus applications providing comprehensive
       metrics, trends, and business intelligence capabilities across multiple domains.</Description>
     <PackageId>Acontplus.Analytics</PackageId>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Billing/Acontplus.Billing.csproj
+++ b/src/Acontplus.Billing/Acontplus.Billing.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Acontplus.Billing</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Notifications/Acontplus.Notifications.csproj
+++ b/src/Acontplus.Notifications/Acontplus.Notifications.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Acontplus.Notifications</PackageId>
-    <Version>1.6.5</Version>
+    <Version>1.6.6</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.csproj
+++ b/src/Acontplus.Persistence.PostgreSQL/Acontplus.Persistence.PostgreSQL.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Acontplus.Persistence.PostgreSQL</PackageId>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.csproj
+++ b/src/Acontplus.Persistence.SqlServer/Acontplus.Persistence.SqlServer.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Acontplus.Persistence.SqlServer</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>

--- a/src/Acontplus.Reports/Acontplus.Reports.csproj
+++ b/src/Acontplus.Reports/Acontplus.Reports.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>Acontplus.Reports</PackageId>
-    <Version>1.7.8</Version>
+    <Version>1.7.9</Version>
     <Authors>Ivan Paz</Authors>
     <Company>Acontplus</Company>
     <Product>Acontplus .NET Libraries</Product>


### PR DESCRIPTION
- Upgrade actions/checkout from v4 to v7
- Upgrade actions/setup-dotnet from v4 to v5
- Upgrade softprops/action-gh-release from v1 to v2
- Upgrade actions/github-script from v7 to v9
- Standardize YAML string quoting to double quotes for consistency
- Update DOTNET_VERSION environment variable formatting across all workflows
- Apply consistent formatting to workflow input descriptions in cascade-publish.yml
- Maintain compatibility with current GitHub Actions ecosystem standards